### PR TITLE
Fixed Jython installer to standalone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,7 @@ ENV JYTHON_VERSION 2.7.2
 RUN apk --update --no-cache add openssl ca-certificates ttf-dejavu curl bash
 RUN mkdir -p /opt/burp /work
 RUN adduser -D -s /bin/sh user user && chown -R user /work
-RUN curl -L "http://search.maven.org/remotecontent?filepath=org/python/jython-installer/${JYTHON_VERSION}/jython-installer-${JYTHON_VERSION}.jar" -o jython_installer-${JYTHON_VERSION}.jar && \
-    java -jar jython_installer-${JYTHON_VERSION}.jar -s -d /jython-${JYTHON_VERSION} -i ensurepip && \
-    ln -s /jython-${JYTHON_VERSION}/bin/jython /usr/bin && \
-    ln -s /jython-${JYTHON_VERSION}/bin/pip /usr/bin && \
-    rm jython_installer-${JYTHON_VERSION}.jar
+RUN curl -L "https://repo1.maven.org/maven2/org/python/jython-standalone/${JYTHON_VERSION}/jython-standalone-${JYTHON_VERSION}.jar" -o /usr/bin/jython.jar
 RUN echo "Success"
 
 ADD bin/* /opt/burp/


### PR DESCRIPTION
Docker image is now 240MB.